### PR TITLE
Reload accessibility elements on text change

### DIFF
--- a/HyperLabel/HyperLabelPresenter.swift
+++ b/HyperLabel/HyperLabelPresenter.swift
@@ -123,10 +123,12 @@ public final class HyperLabelPresenter<TextView: UIView> where TextView: TextCon
             textView.observe(\.text, options: [.new, .old]) { [weak self] _, change in
                 guard let self = self, change.oldValue != change.newValue else { return }
                 self.didChangeText()
+                self.reloadAccessibilityElements()
             },
             textView.observe(\.attributedText, options: [.new, .old]) { [weak self] _, change in
                 guard let self = self, change.oldValue != change.newValue else { return }
                 self.didChangeText()
+                self.reloadAccessibilityElements()
             },
             textView.observe(\.bounds, options: [.new, .old, .initial]) { [weak self] _, change in
                 guard let self = self, change.oldValue != change.newValue else { return }


### PR DESCRIPTION
In the current version accessibility value of the HLHyperLabel is not updated in some cases. For example, if you set text that takes the same space as the previous one. For example: "Message 4" -> "Message 0". In this case KVO observers for `bounds` and `frame` will not be triggered and therefore accessibility elements will not be reloaded. 

I simply added `reloadAccessibilityElements()` to `text` and `attributedText` observers.