### PR TITLE
Remove text kvo observation

### DIFF
--- a/HyperLabel/HLHyperLabel.swift
+++ b/HyperLabel/HLHyperLabel.swift
@@ -38,4 +38,20 @@ public final class HLHyperLabel: UILabel, HyperLabelProtocol {
         super.init(coder: aDecoder)
         self.initializeHyperLabel()
     }
+
+    var onTextDidChange: (StringChange) -> Void = { _ in }
+
+    public override var text: String? {
+        didSet {
+            self.onTextDidChange(StringChange(newValue: self.text, oldValue: oldValue))
+        }
+    }
+
+    var onAttributedTextChange: (AttributedStringChange) -> Void = { _ in }
+
+    public override var attributedText: NSAttributedString? {
+        didSet {
+            self.onAttributedTextChange(AttributedStringChange(newValue: self.attributedText, oldValue: oldValue))
+        }
+    }
 }

--- a/HyperLabel/HyperLabelPresenter.swift
+++ b/HyperLabel/HyperLabelPresenter.swift
@@ -116,19 +116,19 @@ final class HyperLabelPresenter<TextView: UIView> where TextView: TextContainerD
 
     private var textViewObservers: [NSKeyValueObservation] = []
     private func observerTextViewChanges() {
-        guard let textView = self.textView else {
+        guard var textView = self.textView else {
             self.textViewObservers.removeAll()
             return
         }
+        textView.onTextDidChange = { [weak self] change in
+            guard let self = self, change.oldValue != change.newValue else { return }
+            self.didChangeText()
+        }
+        textView.onAttributedTextChange = { [weak self] change in
+            guard let self = self, change.oldValue != change.newValue else { return }
+            self.didChangeText()
+        }
         self.textViewObservers = [
-            textView.observe(\.text, options: [.new, .old]) { [weak self] _, change in
-                guard let self = self, change.oldValue != change.newValue else { return }
-                self.didChangeText()
-            },
-            textView.observe(\.attributedText, options: [.new, .old]) { [weak self] _, change in
-                guard let self = self, change.oldValue != change.newValue else { return }
-                self.didChangeText()
-            },
             textView.observe(\.bounds, options: [.new, .old, .initial]) { [weak self] _, change in
                 guard let self = self, change.oldValue != change.newValue else { return }
                 self.reloadAccessibilityElements()

--- a/HyperLabel/HyperLabelPresenter.swift
+++ b/HyperLabel/HyperLabelPresenter.swift
@@ -111,6 +111,7 @@ public final class HyperLabelPresenter<TextView: UIView> where TextView: TextCon
     private func didChangeText() {
         guard self.shouldReactToTextChange else { return }
         self.linkRegistry.clear()
+        self.reloadAccessibilityElements()
     }
 
     private var textViewObservers: [NSKeyValueObservation] = []
@@ -123,12 +124,10 @@ public final class HyperLabelPresenter<TextView: UIView> where TextView: TextCon
             textView.observe(\.text, options: [.new, .old]) { [weak self] _, change in
                 guard let self = self, change.oldValue != change.newValue else { return }
                 self.didChangeText()
-                self.reloadAccessibilityElements()
             },
             textView.observe(\.attributedText, options: [.new, .old]) { [weak self] _, change in
                 guard let self = self, change.oldValue != change.newValue else { return }
                 self.didChangeText()
-                self.reloadAccessibilityElements()
             },
             textView.observe(\.bounds, options: [.new, .old, .initial]) { [weak self] _, change in
                 guard let self = self, change.oldValue != change.newValue else { return }

--- a/HyperLabel/HyperLabelPresenter.swift
+++ b/HyperLabel/HyperLabelPresenter.swift
@@ -23,7 +23,7 @@
 
 import UIKit
 
-public final class HyperLabelPresenter<TextView: UIView> where TextView: TextContainerData {
+final class HyperLabelPresenter<TextView: UIView> where TextView: TextContainerData {
 
     // MARK: - Type declarations
 
@@ -38,7 +38,7 @@ public final class HyperLabelPresenter<TextView: UIView> where TextView: TextCon
         }
     }
 
-    public typealias Handler = () -> Void
+    typealias Handler = () -> Void
 
     // MARK: - Private properties
 
@@ -50,26 +50,26 @@ public final class HyperLabelPresenter<TextView: UIView> where TextView: TextCon
 
     // MARK: - Instantiation
 
-    public init() {}
+    init() {}
 
-    // MARK: - Public API
+    // MARK: - API
 
-    public var extendsLinkTouchArea: Bool = true
+    var extendsLinkTouchArea: Bool = true
 
-    public weak var textView: TextView? {
+    weak var textView: TextView? {
         didSet {
             self.observerTextViewChanges()
         }
     }
 
-    public var additionalLinkAttributes: [NSAttributedString.Key: Any] {
+    var additionalLinkAttributes: [NSAttributedString.Key: Any] {
         get { return self.textStyler.linkAttributes }
         set { self.textStyler.linkAttributes = newValue }
     }
 
-    public func addLink(addLinkWithRange range: NSRange,
-                        accessibilityIdentifier: String?,
-                        withHandler handler: @escaping Handler) {
+    func addLink(addLinkWithRange range: NSRange,
+                 accessibilityIdentifier: String?,
+                 withHandler handler: @escaping Handler) {
         guard let textView = self.textView else {
             assertionFailure("textView is nil")
             return
@@ -87,7 +87,7 @@ public final class HyperLabelPresenter<TextView: UIView> where TextView: TextCon
     }
 
     @objc
-    public func handleTapGesture(sender: UITapGestureRecognizer) {
+    func handleTapGesture(sender: UITapGestureRecognizer) {
         guard sender.state == .ended else { return }
         guard let view = self.textView else {
             assertionFailure("textView is nil")

--- a/HyperLabel/HyperLabelProtocol.swift
+++ b/HyperLabel/HyperLabelProtocol.swift
@@ -39,7 +39,7 @@ extension HyperLabelProtocol {
 
 private var presenterAssociatedKey = 0
 
-extension HyperLabelProtocol where Self: UILabel {
+extension HyperLabelProtocol where Self: HLHyperLabel {
 
     private typealias Presenter = HyperLabelPresenter<Self>
 
@@ -109,7 +109,7 @@ extension HyperLabelProtocol where Self: UILabel {
     }
 }
 
-private extension UILabel {
+private extension HLHyperLabel {
     func setupForHyperLabel() {
         self.isAccessibilityElement = false
         self.isUserInteractionEnabled = true

--- a/HyperLabel/TextContainerData.swift
+++ b/HyperLabel/TextContainerData.swift
@@ -23,17 +23,26 @@
 
 import UIKit
 
-@objc
+struct Change<T> {
+    let newValue: T
+    let oldValue: T
+}
+
+typealias StringChange = Change<String?>
+typealias AttributedStringChange = Change<NSAttributedString?>
+
 protocol TextContainerData {
     var font: UIFont! { get }
-    @objc var text: String? { get }
-    @objc var attributedText: NSAttributedString? { get set }
+    var text: String? { get }
+    var attributedText: NSAttributedString? { get set }
     var lineBreakMode: NSLineBreakMode { get }
     var numberOfLines: Int { get }
     var size: CGSize { get }
+    var onTextDidChange: (StringChange) -> Void { get set }
+    var onAttributedTextChange: (AttributedStringChange) -> Void { get set }
 }
 
-extension UILabel: TextContainerData {
+extension HLHyperLabel: TextContainerData {
     var size: CGSize {
         return self.bounds.size
     }

--- a/HyperLabel/TextContainerData.swift
+++ b/HyperLabel/TextContainerData.swift
@@ -24,7 +24,7 @@
 import UIKit
 
 @objc
-public protocol TextContainerData {
+protocol TextContainerData {
     var font: UIFont! { get }
     @objc var text: String? { get }
     @objc var attributedText: NSAttributedString? { get set }
@@ -34,7 +34,7 @@ public protocol TextContainerData {
 }
 
 extension UILabel: TextContainerData {
-    public var size: CGSize {
+    var size: CGSize {
         return self.bounds.size
     }
 }


### PR DESCRIPTION
`HLHyperLabel` observes `UILabel.text` and `UILabel.attributedText` properties using KVO for its own needs. It creates race conditions or conflicts with any code which also observes these properties with KVO.
At the same time `HLHyperLabel` is a subclass of the `UILabel`, it can detect `text` and `attributedText` changes on its own.