### PR TITLE
Remove FontLeading from TextCalculations

### DIFF
--- a/HyperLabel/TextLayoutInfoProvider.swift
+++ b/HyperLabel/TextLayoutInfoProvider.swift
@@ -34,6 +34,7 @@ final class TextLayoutInfoProvider {
         self.textContainer = NSTextContainer()
         self.textStorage = NSTextStorage()
 
+        self.layoutManager.usesFontLeading = false
         self.layoutManager.addTextContainer(self.textContainer)
         self.textStorage.addLayoutManager(self.layoutManager)
     }


### PR DESCRIPTION
Leading is impacting the LayoutManager text calculations. Here we set it default to false